### PR TITLE
fix: room database does not process queries after export

### DIFF
--- a/app/src/main/java/vadimerenkov/aucards/ui/SettingsViewModel.kt
+++ b/app/src/main/java/vadimerenkov/aucards/ui/SettingsViewModel.kt
@@ -160,19 +160,19 @@ class SettingsViewModel(
 	fun exportDatabase(uri: Uri, context: Context) {
 		viewModelScope.launch {
 			try {
-				val tmp = File.createTempFile("aucards_export", ".db", context.cacheDir)
+				val temp = File.createTempFile("aucards_export", ".db", context.cacheDir)
 				
 				val db = database.openHelper.writableDatabase
-				db.execSQL("VACUUM INTO '${tmp.absolutePath}'")
+				db.execSQL("VACUUM INTO '${temp.absolutePath}'")
 
 				context.contentResolver.openOutputStream(uri)?.use { output ->
-					tmp.inputStream().use { input ->
+					temp.inputStream().use { input ->
 						input.copyTo(output)
 					}
 				}
 
-				Log.i(TAG, "Database path is: ${tmp.path}")
-				tmp.delete()
+				Log.i(TAG, "Database path is: ${temp.path}")
+				temp.delete()
 			} catch (e: Exception) {
 				Log.e(TAG, "Export database error: $e")
 			}


### PR DESCRIPTION
Hello there, this PR is to fix issue #19 

`Before`: The export flow disabled WAL mode `database.openHelper.setWriteAheadLoggingEnabled(false)` before copying the database. This conflicted with room, which depends on WAL and the `room_table_modification_log` table, but after export toggling WAL back on was not enough to restore the db state

`After`: Uses `VACUUM INTO` to generate a clean, consistent copy of the database without modififying  WAL settings